### PR TITLE
Follow ASDF3 guideline of a single primary system per .asd file

### DIFF
--- a/cl-association-rules.asd
+++ b/cl-association-rules.asd
@@ -1,18 +1,19 @@
 (defsystem #:cl-association-rules
-           :name "cl-association-rules"
-           :version "0.0.1"
-           :description "An implementation of the apriori algorithm to mine association rules in Common Lisp."
-           :author "Diogo Franco"
-           :license "MIT"
-           :serial t
-           :components ((:file "package")
-                        (:file "rule")
-                        (:file "apriori")))
+  :version "0.0.1"
+  :description "An implementation of the apriori algorithm to mine association rules in Common Lisp."
+  :author "Diogo Franco"
+  :license "MIT"
+  :serial t
+  :components ((:file "package")
+               (:file "rule")
+               (:file "apriori"))
+  :in-order-to ((test-op (test-op #:cl-association-rules/tests))))
 
-(defsystem #:cl-association-rules-tests
-           :name "cl-association-rules-tests"
-           :version "0.0.1"
-           :description "The tests for the cl-association-rules system."
-           :author "Diogo Franco"
-           :depends-on (#:cl-association-rules #:prove)
-           :components ((:file "tests")))
+(defsystem #:cl-association-rules/tests
+  :version "0.0.1"
+  :description "The tests for the cl-association-rules system."
+  :author "Diogo Franco"
+  :defsystem-depends-on (#:prove-asdf)
+  :depends-on (#:cl-association-rules #:prove)
+  :components ((:test-file "tests"))
+  :perform (test-op (o c) (symbol-call :prove :run c)))


### PR DESCRIPTION
ASDF3 recommends declaring a single primary system per `.asd` file (e.g., `FOO`), with other, optional subsystems being named with a slash (e.g., `FOO/BAR`). This ensures that `FOO/BAR` can be loaded without first having to manually load `FOO`, as would be the case with e.g. `FOO-BAR` (ASDF would look for it in a non-existent `foo-bar.asd`).

See: [info asdf find-system](https://asdf.common-lisp.dev/asdf.html#Components-1)
